### PR TITLE
Chrishonw/address invalid urls with error handling

### DIFF
--- a/Classes/Celestial/Celestial.swift
+++ b/Classes/Celestial/Celestial.swift
@@ -11,6 +11,9 @@ public final class Celestial: NSObject {
     
     enum CSError: Error {
         case invalidURL(String)
+        case urlToDataError(String)
+        case invalidSourceURLError(String)
+        case unknownURLPathExtension(String)
     }
     
     /// Public shared instance property

--- a/Classes/Protocols+Declarations/MiscellaneousDeclarations.swift
+++ b/Classes/Protocols+Declarations/MiscellaneousDeclarations.swift
@@ -185,14 +185,7 @@ internal protocol MediaResourceLoaderDelegate: AnyObject {
 
 
 
-// MARK: - Errors
 
-/// Errors encountered during internal Celestial operations
-enum CLSError: Error {
-    case urlToDataError(String)
-    case invalidSourceURLError(String)
-    case nonExistentFileAtURLError(String)
-}
 
 
 

--- a/Classes/URLViews/URLImageView/URLImageView.swift
+++ b/Classes/URLViews/URLImageView/URLImageView.swift
@@ -43,7 +43,9 @@ import UIKit
                             sourceURLString: String,
                             cacheLocation: ResourceCacheLocation = .inMemory) {
         self.init(delegate: delegate, cacheLocation: cacheLocation)
-        loadImageFrom(urlString: sourceURLString)
+        if let error = loadImageFrom(urlString: sourceURLString) {
+            delegate?.urlCachableView?(self, downloadFailedWith: error)
+        }
     }
     
     public convenience init(delegate: URLCachableViewDelegate?,


### PR DESCRIPTION
Video URLs that don't have file extensions cannot be played by AVURLAsset. Determining a URL's mime type also apparently isn't possible.
So return some kind of error rather leaving the view blank and/or causing a crash when preparing the asset.